### PR TITLE
fix: search stuck forever

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,11 +126,10 @@
     }
   },
   "devDependencies": {
-    "@types/electron": "^1.6.12",
-    "@types/node": "^22.13.0",
+    "@types/node": "^22.13.1",
     "copyfiles": "^2.4.1",
     "electron": "^34.0.2",
-    "electron-builder": "^25.1.8",
+    "electron-builder": "^26.0.3",
     "ts-node": "^10.9.2",
     "typescript": "^5.7.3"
   }

--- a/src/util/llmProviders/ollama.ts
+++ b/src/util/llmProviders/ollama.ts
@@ -1,8 +1,5 @@
 import axios from "axios";
 
-// Define the base URL of the Ollama API
-const OLLAMA_API_BASE_URL = "http://localhost:11434";
-
 type Role = "user" | "system" | "assistant";
 
 interface Message {
@@ -46,7 +43,9 @@ export function createMessages(systemPrompt?: string, prompt?: string | null): M
 export async function runLlm(
     model: string,
     messages: Message[],
-    format?: Format
+    format?: Format,
+    ollamaUrl?: string,
+    ollamaPort?: string
 ): Promise<string> {
     try {
         const parameters = {
@@ -59,8 +58,10 @@ export async function runLlm(
             ...(format && { format }),
         };
 
+        const baseUrl = ollamaUrl && ollamaPort ? `${ollamaUrl}:${ollamaPort}` : "http://localhost:11434";
+
         const response = await axios.post(
-            `${OLLAMA_API_BASE_URL}/api/chat`,
+            `${baseUrl}/api/chat`,
             parameters,
             {
                 headers: {

--- a/src/util/stages/generateQueries.ts
+++ b/src/util/stages/generateQueries.ts
@@ -29,7 +29,10 @@ export async function generateQueries(outputFile: string) {
             );
 
             const messages = createMessages(systemPrompt, scourFile.objective);
-            const response = await runLlm(scourFile.model, messages, format);
+            const response = await runLlm(
+                scourFile.model, messages, format,
+                scourFile.ollamaUrl || undefined,
+                scourFile.ollamaPort?.toString() || undefined);
 
             if (!response) {
                 logger.error("No response from the LLM.");


### PR DESCRIPTION
- Fix for #29 
- Remove the @types/election which is depreciated and not needed as it's included with the electron package.
- Bump electron builder and types/node to current version